### PR TITLE
Material UIのNext対応

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -20,20 +20,6 @@
                     // "@server": "./pages/server"
                 }
             }
-        ],
-        [
-            "babel-plugin-styled-components",
-            {
-                "ssr": true,
-                "displayName": true,
-                "preprocess": false
-            }
-            // "styled-components",
-            // {
-            //     "ssr": true,
-            //     "displayName": true,
-            //     "preprocess": false
-            // }
         ]
     ]
 }

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import Document, { Html, Head, Main, NextScript } from 'next/document';
+import { ServerStyleSheets } from '@material-ui/core/styles';
+
+export default class MyDocument extends Document {
+  render() {
+    return (
+      <Html lang="en">
+        <Head>
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+}
+
+// `getInitialProps` belongs to `_document` (instead of `_app`),
+// it's compatible with server-side generation (SSG).
+MyDocument.getInitialProps = async (ctx) => {
+  // Resolution order
+  //
+  // On the server:
+  // 1. app.getInitialProps
+  // 2. page.getInitialProps
+  // 3. document.getInitialProps
+  // 4. app.render
+  // 5. page.render
+  // 6. document.render
+  //
+  // On the server with error:
+  // 1. document.getInitialProps
+  // 2. app.render
+  // 3. page.render
+  // 4. document.render
+  //
+  // On the client
+  // 1. app.getInitialProps
+  // 2. page.getInitialProps
+  // 3. app.render
+  // 4. page.render
+
+  // Render app and page and get the context of the page with collected side effects.
+  const sheets = new ServerStyleSheets();
+  const originalRenderPage = ctx.renderPage;
+
+  ctx.renderPage = () =>
+    originalRenderPage({
+      enhanceApp: (App) => (props) => sheets.collect(<App {...props} />),
+    });
+
+  const initialProps = await Document.getInitialProps(ctx);
+
+  return {
+    ...initialProps,
+    // Styles fragment is rendered after the app and page rendering finish.
+    styles: [...React.Children.toArray(initialProps.styles), sheets.getStyleElement()],
+  };
+};


### PR DESCRIPTION
とりあえずエラーが出ないようにしました。  
大事なのは_document.jsの内容です。  
.babelrcの記述は多分いらないので消しました。    

comonentsやlayouts、themeフォルダの位置は直していないので別途修正ください。

参考  
https://github.com/mui-org/material-ui/tree/master/examples/nextjs  
https://material-ui.com/guides/server-rendering/